### PR TITLE
feat: add postinstall script to generate Prisma client

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",


### PR DESCRIPTION
Because of https://www.prisma.io/docs/orm/more/help-and-troubleshooting/help-articles/netlify-caching-issue